### PR TITLE
Deep linking from the web version to the native app

### DIFF
--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -175,10 +175,18 @@ GoRouter createWebRouter(
           name: 'Landing',
           path: '/',
           parentNavigatorKey: rootNavigatorKey,
-          builder: (context, state) => WebLandingScreen(
-            voucher: state.uri.queryParameters['voucher'],
-            voucherParams: state.uri.queryParameters['params'],
-          ),
+          builder: (context, state) {
+            String alias = Uri.base.host.split('.').first;
+            if (Uri.base.host.split('.').length >= 4) {
+              alias += '.${Uri.base.host.split('.')[1]}';
+            }
+
+            return WebLandingScreen(
+              voucher: state.uri.queryParameters['voucher'],
+              voucherParams: state.uri.queryParameters['params'],
+              alias: alias,
+            );
+          },
         ),
         ShellRoute(
           navigatorKey: shellNavigatorKey,

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -35,11 +35,28 @@ GoRouter createRouter(
             path: '/',
             parentNavigatorKey: rootNavigatorKey,
             builder: (context, state) {
+              // coming in from a deep link "#/wallet/..." will come as a fragment
               final uri = Uri.parse(state.uri.fragment);
+
+              // determine if we are coming from a wallet deep link
+              String? webWallet;
+              String? webWalletAlias;
+
+              final fragment = state.uri.fragment;
+              if (fragment.contains('/wallet/')) {
+                // attempt to parse the compressed wallet json
+                webWallet = fragment.split('/wallet/').last;
+
+                // attempt to parse the alias
+                webWalletAlias = uri.queryParameters['alias'];
+              }
 
               return LandingScreen(
                 voucher: uri.queryParameters['voucher'],
                 voucherParams: uri.queryParameters['params'],
+                webWallet:
+                    webWallet != null && webWallet.isEmpty ? null : webWallet,
+                webWalletAlias: webWalletAlias,
               );
             }),
         ShellRoute(

--- a/lib/screens/landing/screen.dart
+++ b/lib/screens/landing/screen.dart
@@ -20,12 +20,14 @@ class LandingScreen extends StatefulWidget {
   final String? voucher;
   final String? voucherParams;
   final String? webWallet;
+  final String? webWalletAlias;
 
   const LandingScreen({
     super.key,
     this.voucher,
     this.voucherParams,
     this.webWallet,
+    this.webWalletAlias,
   });
 
   @override
@@ -59,7 +61,10 @@ class LandingScreenState extends State<LandingScreen>
 
     // load a deep linked wallet from web
     if (widget.webWallet != null) {
-      address = await _appLogic.importWebWallet(widget.webWallet!);
+      address = await _appLogic.importWebWallet(
+        widget.webWallet!,
+        widget.webWalletAlias ?? 'app',
+      );
     }
 
     // load the last wallet if there was no deeplink

--- a/lib/screens/landing/screen.dart
+++ b/lib/screens/landing/screen.dart
@@ -19,11 +19,13 @@ import 'package:provider/provider.dart';
 class LandingScreen extends StatefulWidget {
   final String? voucher;
   final String? voucherParams;
+  final String? webWallet;
 
   const LandingScreen({
     super.key,
     this.voucher,
     this.voucherParams,
+    this.webWallet,
   });
 
   @override
@@ -49,17 +51,23 @@ class LandingScreenState extends State<LandingScreen>
   void onLoad() async {
     final navigator = GoRouter.of(context);
 
+    // set up recovery
     await handleAppleRecover();
     await handleAndroidRecover();
 
-    final address = await _appLogic.loadLastWallet();
+    String? address;
+
+    // load a deep linked wallet from web
+    if (widget.webWallet != null) {
+      address = await _appLogic.importWebWallet(widget.webWallet!);
+    }
+
+    // load the last wallet if there was no deeplink
+    address ??= await _appLogic.loadLastWallet();
 
     if (address == null) {
       return;
     }
-
-    print('voucher: ${widget.voucher}');
-    print('voucherParams: ${widget.voucherParams}');
 
     String url = '/wallet/$address';
     if (widget.voucher != null && widget.voucherParams != null) {

--- a/lib/screens/landing/screen.web.dart
+++ b/lib/screens/landing/screen.web.dart
@@ -8,11 +8,13 @@ import 'package:lottie/lottie.dart';
 class WebLandingScreen extends StatefulWidget {
   final String? voucher;
   final String? voucherParams;
+  final String? alias;
 
   const WebLandingScreen({
     super.key,
     this.voucher,
     this.voucherParams,
+    this.alias,
   });
 
   @override
@@ -35,6 +37,20 @@ class WebLandingScreenState extends State<WebLandingScreen>
     });
   }
 
+  String parseParamsFromWidget() {
+    String params = '';
+    if (widget.voucher != null && widget.voucherParams != null) {
+      params += '&voucher=${widget.voucher}';
+      params += '&params=${widget.voucherParams}';
+    }
+
+    if (widget.alias != null) {
+      params += '&alias=${widget.alias}';
+    }
+
+    return params.replaceFirst('&', '?');
+  }
+
   void onLoad() async {
     final navigator = GoRouter.of(context);
 
@@ -43,13 +59,7 @@ class WebLandingScreenState extends State<WebLandingScreen>
     final lastEncodedWallet = await _appLogic.getLastEncodedWallet();
 
     if (lastEncodedWallet != null) {
-      String url = '/wallet/$lastEncodedWallet';
-      if (widget.voucher != null && widget.voucherParams != null) {
-        url += '?voucher=${widget.voucher}';
-        url += '&params=${widget.voucherParams}';
-      }
-
-      navigator.go(url);
+      navigator.go('/wallet/$lastEncodedWallet${parseParamsFromWidget()}');
       return;
     }
 
@@ -59,13 +69,7 @@ class WebLandingScreenState extends State<WebLandingScreen>
       return;
     }
 
-    String url = '/wallet/$wallet';
-    if (widget.voucher != null && widget.voucherParams != null) {
-      url += '?voucher=${widget.voucher}';
-      url += '&params=${widget.voucherParams}';
-    }
-
-    navigator.go(url);
+    navigator.go('/wallet/$wallet${parseParamsFromWidget()}');
   }
 
   @override

--- a/lib/screens/wallet/screen.web.dart
+++ b/lib/screens/wallet/screen.web.dart
@@ -126,9 +126,9 @@ class BurnerWalletScreenState extends State<BurnerWalletScreen> {
 
         final encoded = jsonEncode(converted);
 
-        navigator.go('/wallet/v2-${base64Encode(encoded.codeUnits)}');
+        navigator.go(
+            '/wallet/v2-${base64Encode(encoded.codeUnits)}?alias=${widget.alias}');
       }
-      // _wallet = QR.fromCompressedJson(widget.encoded).toQRWallet();
     } catch (exception, stackTrace) {
       // something is wrong with the encoding
       await Sentry.captureException(

--- a/lib/services/config/config.dart
+++ b/lib/services/config/config.dart
@@ -279,12 +279,12 @@ class ConfigService {
         '${Uri.base.scheme}://${Uri.base.host}:${Uri.base.port}/wallet-config';
 
     _api = APIService(baseURL: url);
-    _alias = alias;
+    _alias = alias == 'localhost' ? 'app' : alias;
   }
 
   void init(String endpoint, String alias) {
     _api = APIService(baseURL: endpoint);
-    _alias = alias;
+    _alias = alias == 'localhost' ? 'app' : alias;
   }
 
   Future<Config> _getConfig() async {

--- a/lib/state/app/logic.dart
+++ b/lib/state/app/logic.dart
@@ -10,6 +10,7 @@ import 'package:citizenwallet/services/wallet/models/qr/wallet.dart';
 import 'package:citizenwallet/services/wallet/utils.dart';
 import 'package:citizenwallet/state/app/state.dart';
 import 'package:citizenwallet/utils/delay.dart';
+import 'package:citizenwallet/utils/uint8.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -289,17 +290,39 @@ class AppLogic {
     return null;
   }
 
-  Future<QRWallet?> importWebWallet(String qrWallet) async {
+  Future<String?> importWebWallet(String webWallet) async {
     try {
       _appState.importLoadingReq();
 
-      final QRWallet wallet = QR.fromCompressedJson(qrWallet).toQRWallet();
+      final decoded = convertUint8ListToString(
+          base64Decode(webWallet.replaceFirst('v2-', '')));
 
-      await wallet.verifyData();
+      final password = dotenv.get('WEB_BURNER_PASSWORD');
+
+      final wallet = Wallet.fromJson(decoded, password);
+
+      final credentials = wallet.privateKey;
+
+      final address = credentials.address.hexEip55;
+
+      final existing = await _encPrefs.getWalletBackup(address);
+      if (existing != null) {
+        return existing.address;
+      }
+
+      await _encPrefs.setWalletBackup(
+        BackupWallet(
+          address: address,
+          privateKey: bytesToHex(credentials.privateKey),
+          name: 'Imported Web Wallet',
+        ),
+      );
+
+      await _preferences.setLastWallet(address);
 
       _appState.importLoadingSuccess();
 
-      return wallet;
+      return address;
     } catch (exception, stackTrace) {
       Sentry.captureException(
         exception,

--- a/lib/state/app/logic.dart
+++ b/lib/state/app/logic.dart
@@ -290,8 +290,14 @@ class AppLogic {
     return null;
   }
 
-  Future<String?> importWebWallet(String webWallet) async {
+  Future<String?> importWebWallet(
+    String webWallet,
+    String alias,
+  ) async {
     try {
+      // TODO: accounts with aliases
+      print('alias: $alias');
+
       _appState.importLoadingReq();
 
       final decoded = convertUint8ListToString(


### PR DESCRIPTION
Native:
- parse an incoming web wallet
- save it and switch to it
- switch to it if it's already saved
- read an incoming alias from a deep link (for future use for multi-community on native)

Web:
- add the subdomain/alias as a query param (native cannot see the original domain from the deep link)