### PR TITLE
Dynamic token decimals & voucher link alias inclusion

### DIFF
--- a/assets/data/configs.json
+++ b/assets/data/configs.json
@@ -205,7 +205,8 @@
             "entrypoint_address": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
             "account_factory_address": "0x9406Cc6185a346906296840746125a0E44976454",
             "paymaster_rpc_url": "https://api.stackup.sh/v1/paymaster/b9a4ab767689e3142ac60e761e96a9d3361ad07366bc4c850fa0cd311c923bdd",
-            "paymaster_type": "payg"
+            "paymaster_type": "payg",
+            "gas_extra_percentage": 50
         },
         "token": {
             "standard": "erc20",

--- a/assets/data/configs.json
+++ b/assets/data/configs.json
@@ -35,11 +35,12 @@
             "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
             "name": "USD Coin",
             "symbol": "USDC",
-            "decimals": 2
+            "decimals": 6
         },
         "profile": {
             "address": "0xA63DFccB8a39a3DFE4479b33190b12019Ee594E7"
-        }
+        },
+        "version": 1
     },
     {
         "community": {
@@ -79,12 +80,12 @@
             "address": "0x9b1a0D2951b11Ac26A6cBbd5aEf2c4cb014b3B6e",
             "name": "Regens Unite Token",
             "symbol": "RGN",
-            "decimals": 2
+            "decimals": 6
         },
         "profile": {
             "address": "0xAE76B1C6818c1DD81E20ccefD3e72B773068ABc9"
         },
-        "version": 1
+        "version": 2
     },
     {
         "community": {
@@ -123,11 +124,12 @@
             "address": "0x845598Da418890a674cbaBA26b70807aF0c61dFE",
             "name": "OAK Community Currency",
             "symbol": "OAK",
-            "decimals": 2
+            "decimals": 6
         },
         "profile": {
             "address": "0xFE213c74e25505B232CE4C7f89647408bE6f71d2"
-        }
+        },
+        "version": 1
     },
     {
         "community": {
@@ -166,10 +168,55 @@
             "address": "0x58a2993A618Afee681DE23dECBCF535A58A080BA",
             "name": "SFLUV Coin",
             "symbol": "SFLUV",
-            "decimals": 2
+            "decimals": 6
         },
         "profile": {
             "address": "0x05e2Fb34b4548990F96B3ba422eA3EF49D5dAa99"
-        }
+        },
+        "version": 1
+    },
+    {
+        "community": {
+            "name": "Stable Coin",
+            "description": "SBC is a digital dollar stablecoin issued by Brale",
+            "url": "https://brale.xyz/",
+            "alias": "middlebit.xyz",
+            "logo": "https://middlebit.xyz/wallet-config/_images/sbc.svg",
+            "custom_domain": "middlebit.xyz"
+        },
+        "scan": {
+            "url": "https://polygonscan.com",
+            "name": "Polygon Explorer"
+        },
+        "indexer": {
+            "url": "https://indexer-polygon.internal.citizenwallet.xyz",
+            "ipfs_url": "https://indexer-polygon.internal.citizenwallet.xyz",
+            "key": "x"
+        },
+        "ipfs": {
+            "url": "https://ipfs.internal.citizenwallet.xyz"
+        },
+        "node": {
+            "url": "https://nd-147-012-483.p2pify.com/d8ba4ac942ec62a14e0cc844d373d9d2",
+            "ws_url": "wss://ws-nd-147-012-483.p2pify.com/d8ba4ac942ec62a14e0cc844d373d9d2"
+        },
+        "erc4337": {
+            "rpc_url": "https://api.stackup.sh/v1/node/b9a4ab767689e3142ac60e761e96a9d3361ad07366bc4c850fa0cd311c923bdd",
+            "entrypoint_address": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+            "account_factory_address": "0x9406Cc6185a346906296840746125a0E44976454",
+            "paymaster_rpc_url": "https://api.stackup.sh/v1/paymaster/b9a4ab767689e3142ac60e761e96a9d3361ad07366bc4c850fa0cd311c923bdd",
+            "paymaster_type": "payg"
+        },
+        "token": {
+            "standard": "erc20",
+            "address": "0xfdcC3dd6671eaB0709A4C0f3F53De9a333d80798",
+            "name": "Stable Coin",
+            "symbol": "SBC",
+            "decimals": 18
+        },
+        "profile": {
+            "address": "0xcA0a75EF803a364C83c5EAE7Eb889aE7419c9dF2"
+        },
+        "version": 1
     }
 ]

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -101,16 +101,16 @@ PODS:
     - Flutter
     - FlutterMacOS
   - PromisesObjC (2.3.1)
-  - SDWebImage (5.17.0):
-    - SDWebImage/Core (= 5.17.0)
-  - SDWebImage/Core (5.17.0)
-  - Sentry/HybridSDK (8.9.1):
-    - SentryPrivate (= 8.9.1)
+  - SDWebImage (5.18.1):
+    - SDWebImage/Core (= 5.18.1)
+  - SDWebImage/Core (5.18.1)
+  - Sentry/HybridSDK (8.11.0):
+    - SentryPrivate (= 8.11.0)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.9.1)
-  - SentryPrivate (8.9.1)
+    - Sentry/HybridSDK (= 8.11.0)
+  - SentryPrivate (8.11.0)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -204,10 +204,10 @@ SPEC CHECKSUMS:
   package_info_plus: fd030dabf36271f146f1f3beacd48f564b0f17f7
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
-  SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
-  Sentry: e3203780941722a1fcfee99e351de14244c7f806
-  sentry_flutter: 8f0ffd53088e6a4d50c095852c5cad9e4405025c
-  SentryPrivate: 5e3683390f66611fc7c6215e27645873adb55d13
+  SDWebImage: ebdbcebc7933a45226d9313bd0118bc052ad458b
+  Sentry: 39d57e691e311bdb73bc1ab5bbebbd6bc890050d
+  sentry_flutter: b2feefdad5b0f06602347172bc7257e8e9da5562
+  SentryPrivate: 48712023cdfd523735c2edb6b06bedf26c4730a3
   share_plus: 599aa54e4ea31d4b4c0e9c911bcc26c55e791028
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a

--- a/lib/modals/vouchers/screen.dart
+++ b/lib/modals/vouchers/screen.dart
@@ -122,13 +122,14 @@ class VouchersModalState extends State<VouchersModal> {
     }
 
     if (option == 'return') {
+      print(amount);
       final confirm = await showCupertinoModalPopup<bool?>(
         context: context,
         barrierDismissible: true,
         builder: (modalContext) => ConfirmModal(
           title: 'Return Voucher',
           details: [
-            '${(double.tryParse(amount) ?? 0.0) / 1000} ${wallet?.symbol ?? ''} will be return to your wallet.',
+            '${(double.tryParse(amount) ?? 0.0).toStringAsFixed(2)} ${wallet?.symbol ?? ''} will be returned to your wallet.',
           ],
           confirmText: 'Return',
         ),

--- a/lib/modals/vouchers/screen.dart
+++ b/lib/modals/vouchers/screen.dart
@@ -122,7 +122,6 @@ class VouchersModalState extends State<VouchersModal> {
     }
 
     if (option == 'return') {
-      print(amount);
       final confirm = await showCupertinoModalPopup<bool?>(
         context: context,
         barrierDismissible: true,

--- a/lib/modals/wallet/pick_sender.dart
+++ b/lib/modals/wallet/pick_sender.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:citizenwallet/services/wallet/contracts/profile.dart';
+import 'package:citizenwallet/services/wallet/utils.dart';
 import 'package:citizenwallet/state/profiles/logic.dart';
 import 'package:citizenwallet/state/profiles/selectors.dart';
 import 'package:citizenwallet/state/profiles/state.dart';
@@ -175,8 +176,12 @@ class PickeSenderModalState extends State<PickeSenderModal>
     final wallet = context.select((WalletState state) => state.wallet);
     final balance =
         double.tryParse(wallet != null ? wallet.balance : '0.0') ?? 0.0;
+
     final formattedBalance = formatAmount(
-      balance,
+      double.parse(fromDoubleUnit(
+        '$balance',
+        decimals: wallet?.decimalDigits ?? 2,
+      )),
       decimalDigits: 2,
     );
 

--- a/lib/modals/wallet/pick_sender.dart
+++ b/lib/modals/wallet/pick_sender.dart
@@ -177,7 +177,7 @@ class PickeSenderModalState extends State<PickeSenderModal>
         double.tryParse(wallet != null ? wallet.balance : '0.0') ?? 0.0;
     final formattedBalance = formatAmount(
       balance,
-      decimalDigits: wallet != null ? wallet.decimalDigits : 2,
+      decimalDigits: 2,
     );
 
     final invalidAddress = context.select(

--- a/lib/modals/wallet/send.dart
+++ b/lib/modals/wallet/send.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:citizenwallet/modals/wallet/pick_sender.dart';
 import 'package:citizenwallet/modals/wallet/voucher.dart';
 import 'package:citizenwallet/services/wallet/contracts/profile.dart';
+import 'package:citizenwallet/services/wallet/utils.dart';
 import 'package:citizenwallet/state/profiles/logic.dart';
 import 'package:citizenwallet/state/profiles/state.dart';
 import 'package:citizenwallet/state/wallet/logic.dart';
@@ -359,8 +360,12 @@ class SendModalState extends State<SendModal> with TickerProviderStateMixin {
     final wallet = context.select((WalletState state) => state.wallet);
     final balance =
         double.tryParse(wallet != null ? wallet.balance : '0.0') ?? 0.0;
+
     final formattedBalance = formatAmount(
-      balance,
+      double.parse(fromDoubleUnit(
+        '$balance',
+        decimals: wallet?.decimalDigits ?? 2,
+      )),
       decimalDigits: 2,
     );
 

--- a/lib/modals/wallet/send.dart
+++ b/lib/modals/wallet/send.dart
@@ -361,7 +361,7 @@ class SendModalState extends State<SendModal> with TickerProviderStateMixin {
         double.tryParse(wallet != null ? wallet.balance : '0.0') ?? 0.0;
     final formattedBalance = formatAmount(
       balance,
-      decimalDigits: wallet != null ? wallet.decimalDigits : 2,
+      decimalDigits: 2,
     );
 
     final invalidScanMessage = context.select(

--- a/lib/modals/wallet/voucher_read.dart
+++ b/lib/modals/wallet/voucher_read.dart
@@ -2,14 +2,15 @@ import 'package:citizenwallet/state/profiles/logic.dart';
 import 'package:citizenwallet/state/profiles/state.dart';
 import 'package:citizenwallet/state/vouchers/logic.dart';
 import 'package:citizenwallet/state/vouchers/state.dart';
+import 'package:citizenwallet/state/wallet/state.dart';
 import 'package:citizenwallet/theme/colors.dart';
 import 'package:citizenwallet/utils/delay.dart';
 import 'package:citizenwallet/widgets/blurry_child.dart';
 import 'package:citizenwallet/widgets/button.dart';
+import 'package:citizenwallet/widgets/coin_logo.dart';
 import 'package:citizenwallet/widgets/header.dart';
 import 'package:citizenwallet/widgets/profile/profile_badge.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:provider/provider.dart';
@@ -93,6 +94,8 @@ class VoucherReadModalState extends State<VoucherReadModal>
 
     final width = MediaQuery.of(context).size.width;
 
+    final config = context.select((WalletState state) => state.config);
+
     final voucher =
         context.select((VoucherState state) => state.viewingVoucher);
     final viewLoading =
@@ -155,18 +158,16 @@ class VoucherReadModalState extends State<VoucherReadModal>
                           ),
                           const SizedBox(height: 10),
                           SizedBox(
-                            height: 300,
-                            width: 300,
+                            height: 120,
+                            width: 120,
                             child: Center(
                               child: viewLoading || voucher == null
                                   ? CupertinoActivityIndicator(
                                       color: ThemeColors.subtle
                                           .resolveFrom(context))
-                                  : SvgPicture.asset(
-                                      'assets/icons/voucher.svg',
-                                      semanticsLabel: 'voucher icon',
-                                      height: 200,
-                                      width: 200,
+                                  : CoinLogo(
+                                      size: 100,
+                                      logo: config?.community.logo,
                                     ),
                             ),
                           ),

--- a/lib/models/wallet.dart
+++ b/lib/models/wallet.dart
@@ -55,11 +55,6 @@ class CWWallet {
   String get balance => _balance;
   double get doubleBalance => double.tryParse(_balance) ?? 0.0;
 
-  String get formattedBalance => formatAmount(
-        double.tryParse(_balance) ?? 0.0,
-        decimalDigits: decimalDigits,
-      );
-
   // convert to Wallet object from JSON
   CWWallet.fromJson(Map<String, dynamic> json)
       : name = json['name'],

--- a/lib/screens/transaction/screen.dart
+++ b/lib/screens/transaction/screen.dart
@@ -101,7 +101,7 @@ class TransactionScreenState extends State<TransactionScreen> {
         walletLogic: widget.logic,
         profilesLogic: widget.profilesLogic,
         to: address,
-        amount: '${(double.tryParse(amount) ?? 0.0) / 1000}',
+        amount: (double.tryParse(amount) ?? 0.0).toStringAsFixed(2),
       ),
     );
 

--- a/lib/screens/wallet/wallet_actions.dart
+++ b/lib/screens/wallet/wallet_actions.dart
@@ -38,8 +38,10 @@ class WalletActions extends StatelessWidget {
 
     final hasPending = context.select(selectHasProcessingTransactions);
     final newBalance = context.select(selectWalletBalance);
-    final formattedBalance = formatAmount(newBalance > 0 ? newBalance : 0.0,
-        decimalDigits: wallet != null ? wallet.decimalDigits : 2);
+    final formattedBalance = formatAmount(
+      newBalance > 0 ? newBalance : 0.0,
+      decimalDigits: 2,
+    );
 
     final balance = wallet != null ? double.parse(wallet.balance) : 0.0;
 

--- a/lib/screens/wallet/wallet_actions.dart
+++ b/lib/screens/wallet/wallet_actions.dart
@@ -1,3 +1,4 @@
+import 'package:citizenwallet/services/wallet/utils.dart';
 import 'package:citizenwallet/state/wallet/selectors.dart';
 import 'package:citizenwallet/state/wallet/state.dart';
 import 'package:citizenwallet/theme/colors.dart';
@@ -38,8 +39,12 @@ class WalletActions extends StatelessWidget {
 
     final hasPending = context.select(selectHasProcessingTransactions);
     final newBalance = context.select(selectWalletBalance);
+
     final formattedBalance = formatAmount(
-      newBalance > 0 ? newBalance : 0.0,
+      double.parse(fromDoubleUnit(
+        '${newBalance > 0 ? newBalance : 0.0}',
+        decimals: wallet?.decimalDigits ?? 2,
+      )),
       decimalDigits: 2,
     );
 

--- a/lib/services/config/config.dart
+++ b/lib/services/config/config.dart
@@ -413,6 +413,20 @@ class ConfigService {
 
     final cachedConfig = _pref.getConfig(_alias);
     if (cachedConfig != null) {
+      final response = await _api
+          .get(
+              url:
+                  '/$_alias/config.json?cachebuster=${generateCacheBusterValue()}')
+          .timeout(
+            const Duration(seconds: 2),
+            onTimeout: () => null,
+          );
+
+      if (response != null) {
+        _pref.setConfig(_alias, response);
+        return Config.fromJson(response);
+      }
+
       return Config.fromJson(cachedConfig);
     }
 

--- a/lib/services/wallet/utils.dart
+++ b/lib/services/wallet/utils.dart
@@ -1,21 +1,57 @@
 import 'dart:convert';
 import 'dart:typed_data';
+import 'dart:math';
 import 'package:archive/archive.dart';
 import 'package:citizenwallet/utils/uint8.dart';
 import 'package:web3dart/crypto.dart';
 import 'package:web3dart/web3dart.dart';
 
-// final gwei = BigInt.from(10).pow(9);
-final ether = BigInt.from(10).pow(18);
-// final finney = BigInt.from(10).pow(15);
-final finney = BigInt.from(10).pow(3);
-
-BigInt toUnit(String amount) {
-  return BigInt.parse(amount) * finney;
+EtherAmount toEtherAmount(BigInt amount, {int decimals = 6}) {
+  EtherUnit unit = switch (decimals) {
+    0 => EtherUnit.wei,
+    3 => EtherUnit.wei,
+    6 => EtherUnit.kwei,
+    9 => EtherUnit.mwei,
+    12 => EtherUnit.gwei,
+    15 => EtherUnit.szabo,
+    18 => EtherUnit.finney,
+    _ => EtherUnit.wei,
+  };
+  return EtherAmount.fromBigInt(unit, amount);
 }
 
-String fromUnit(BigInt amount) {
-  return BigInt.from(amount / finney).toString();
+BigInt toWeiUnit(BigInt amount, {int decimals = 6}) {
+  EtherUnit unit = switch (decimals) {
+    0 => EtherUnit.wei,
+    3 => EtherUnit.wei,
+    6 => EtherUnit.kwei,
+    9 => EtherUnit.mwei,
+    12 => EtherUnit.gwei,
+    15 => EtherUnit.szabo,
+    18 => EtherUnit.finney,
+    _ => EtherUnit.wei,
+  };
+  return EtherAmount.fromBigInt(unit, amount).getInWei;
+}
+
+/// toUnit takes a user readable amount and converts it to a BigInt
+BigInt toUnit(String amount, {int decimals = 6}) {
+  final exponent = decimals;
+  return BigInt.from(double.parse(amount) *
+      BigInt.from(10).pow(exponent < 0 ? 0 : exponent).toDouble());
+}
+
+/// fromUnit takes a BigInt and converts it into a user readable amount
+String fromUnit(BigInt amount, {int decimals = 6}) {
+  final pow = decimals;
+  return BigInt.from(amount / BigInt.from(10).pow(pow < 0 ? 0 : pow))
+      .toString();
+}
+
+String fromDoubleUnit(String amount, {int decimals = 6}) {
+  final exponent = decimals;
+  return (double.parse(amount) / pow(10.0, exponent < 0 ? 0 : exponent))
+      .toStringAsFixed(2);
 }
 
 BigInt parseIntFromHex(String hex) {

--- a/lib/services/wallet/wallet.dart
+++ b/lib/services/wallet/wallet.dart
@@ -219,8 +219,9 @@ class WalletService {
 
   /// fetches the balance of a given address
   Future<String> getBalance(String addr) async {
-    return fromUnit(
-      await _contractToken.getBalance(addr),
+    final b = await _contractToken.getBalance(addr);
+    return fromDoubleUnit(
+      b.toString(),
       decimals: currency.decimals,
     );
   }

--- a/lib/services/wallet/wallet.dart
+++ b/lib/services/wallet/wallet.dart
@@ -92,11 +92,9 @@ class WalletService {
             const Duration(seconds: 2),
           );
 
-      final strb = fromUnit(b);
+      _pref.setBalance(_account.hexEip55, b.toString());
 
-      _pref.setBalance(_account.hexEip55, strb);
-
-      return strb;
+      return b.toString();
     } catch (e) {
       //
     }
@@ -221,7 +219,10 @@ class WalletService {
 
   /// fetches the balance of a given address
   Future<String> getBalance(String addr) async {
-    return fromUnit(await _contractToken.getBalance(addr));
+    return fromUnit(
+      await _contractToken.getBalance(addr),
+      decimals: currency.decimals,
+    );
   }
 
   /// set profile data
@@ -507,8 +508,7 @@ class WalletService {
   ) {
     return _contractToken.transferCallData(
       to,
-      EtherAmount.fromBigInt(EtherUnit.kwei, amount).getInWei,
-      // EtherAmount.fromBigInt(EtherUnit.finney, amount).getInWei,
+      amount,
     );
   }
 

--- a/lib/state/vouchers/logic.dart
+++ b/lib/state/vouchers/logic.dart
@@ -231,7 +231,10 @@ class VoucherLogic extends WidgetsBindingObserver {
       _state.createVoucherRequest();
 
       final doubleAmount = balance.replaceAll(',', '.');
-      final parsedAmount = double.parse(doubleAmount) * 1000;
+      final parsedAmount = toUnit(
+        doubleAmount,
+        decimals: _wallet.currency.decimals,
+      );
 
       final config = await _config.config;
 
@@ -262,7 +265,7 @@ class VoucherLogic extends WidgetsBindingObserver {
           address: account.hexEip55,
           alias: config.community.alias,
           name: name ?? 'Voucher for $balance $symbol',
-          balance: '$parsedAmount',
+          balance: parsedAmount.toString(),
           voucher: wallet.toJson(),
           salt: salt,
           creator: _wallet.account.hexEip55,
@@ -272,7 +275,7 @@ class VoucherLogic extends WidgetsBindingObserver {
 
         calldata.add(_wallet.erc20TransferCallData(
           account.hexEip55,
-          BigInt.from(double.parse(doubleAmount) * 1000),
+          parsedAmount,
         ));
 
         final voucher = Voucher(
@@ -333,7 +336,10 @@ class VoucherLogic extends WidgetsBindingObserver {
       );
 
       final doubleAmount = balance.replaceAll(',', '.');
-      final parsedAmount = double.parse(doubleAmount) * 1000;
+      final parsedAmount = toUnit(
+        doubleAmount,
+        decimals: _wallet.currency.decimals,
+      );
 
       final account =
           await _wallet.getAccountAddress(credentials.address.hexEip55);
@@ -344,7 +350,7 @@ class VoucherLogic extends WidgetsBindingObserver {
         address: account.hexEip55,
         alias: config.community.alias,
         name: name ?? 'Voucher for $balance $symbol',
-        balance: '$parsedAmount',
+        balance: parsedAmount.toString(),
         voucher: wallet.toJson(),
         salt: salt,
         creator: _wallet.account.hexEip55,
@@ -356,7 +362,7 @@ class VoucherLogic extends WidgetsBindingObserver {
 
       final calldata = _wallet.erc20TransferCallData(
         account.hexEip55,
-        BigInt.from(double.parse(doubleAmount) * 1000),
+        parsedAmount,
       );
 
       final (hash, userop) = await _wallet.prepareUserop(
@@ -372,10 +378,7 @@ class VoucherLogic extends WidgetsBindingObserver {
           DateTime.now().toUtc(),
           _wallet.account,
           account,
-          EtherAmount.fromBigInt(
-            EtherUnit.kwei,
-            BigInt.from(double.parse(doubleAmount) * 1000),
-          ).getInWei,
+          parsedAmount,
           Uint8List(0),
           TransactionState.sending.name,
         ),
@@ -433,10 +436,10 @@ class VoucherLogic extends WidgetsBindingObserver {
   ) async {
     try {
       final doubleAmount = balance.replaceAll(',', '.');
-      final parsedAmount = double.parse(doubleAmount) / 1000;
+      final parsedAmount = double.parse(doubleAmount);
 
       _sharing.shareVoucher(
-        '$parsedAmount',
+        parsedAmount.toStringAsFixed(2),
         link: link,
         symbol: symbol,
         sharePositionOrigin: sharePositionOrigin,
@@ -459,9 +462,14 @@ class VoucherLogic extends WidgetsBindingObserver {
           Wallet.fromJson(voucher.voucher, '$password${voucher.salt}')
               .privateKey;
 
+      final amount = toUnit(
+        voucher.balance,
+        decimals: _wallet.currency.decimals,
+      );
+
       final calldata = _wallet.erc20TransferCallData(
         _wallet.account.hexEip55,
-        BigInt.from(double.parse(voucher.balance)),
+        amount,
       );
 
       final (hash, userop) = await _wallet.prepareUserop(
@@ -481,10 +489,7 @@ class VoucherLogic extends WidgetsBindingObserver {
           DateTime.now().toUtc(),
           account,
           _wallet.account,
-          EtherAmount.fromBigInt(
-            EtherUnit.kwei,
-            BigInt.from(double.parse(voucher.balance)),
-          ).getInWei,
+          amount,
           Uint8List(0),
           TransactionState.sending.name,
         ),

--- a/lib/state/vouchers/logic.dart
+++ b/lib/state/vouchers/logic.dart
@@ -183,6 +183,8 @@ class VoucherLogic extends WidgetsBindingObserver {
 
       final balance = await _wallet.getBalance(address);
 
+      print('balance: $balance');
+
       await _db.vouchers.updateBalance(address, balance);
 
       final voucher = Voucher(

--- a/lib/state/vouchers/state.dart
+++ b/lib/state/vouchers/state.dart
@@ -49,7 +49,8 @@ class Voucher {
 
     final encodedParams = compress(params);
 
-    String link = '$appLink/#/?voucher=$encoded&params=$encodedParams';
+    String link =
+        '$appLink/#/?voucher=$encoded&params=$encodedParams&alias=$alias';
 
     return link;
   }

--- a/lib/state/vouchers/state.dart
+++ b/lib/state/vouchers/state.dart
@@ -34,7 +34,8 @@ class Voucher {
     required this.archived,
   });
 
-  String get formattedBalance => '${(double.tryParse(balance) ?? 0.0) / 1000}';
+  String get formattedBalance =>
+      (double.tryParse(balance) ?? 0.0).toStringAsFixed(2);
   String get formattedAddress => formatLongText(address);
 
   String getLink(String appLink, String symbol, String voucher) {

--- a/lib/state/wallet/logic.dart
+++ b/lib/state/wallet/logic.dart
@@ -571,8 +571,8 @@ class WalletLogic extends WidgetsBindingObserver {
 
       final cwtransactions = txs.map(
         (tx) => CWTransaction(
-          fromUnit(
-            tx.value,
+          fromDoubleUnit(
+            tx.value.toString(),
             decimals: _wallet.currency.decimals,
           ),
           id: tx.hash,
@@ -691,8 +691,8 @@ class WalletLogic extends WidgetsBindingObserver {
         limit: limit,
       ))
               .map((dbtx) => CWTransaction(
-                    fromUnit(
-                      BigInt.from(dbtx.value),
+                    fromDoubleUnit(
+                      dbtx.value.toString(),
                       decimals: _wallet.currency.decimals,
                     ),
                     id: dbtx.hash,
@@ -740,8 +740,8 @@ class WalletLogic extends WidgetsBindingObserver {
 
           txs.clear();
           txs.addAll(iterableRemoteTxs.map((dbtx) => CWTransaction(
-                fromUnit(
-                  BigInt.from(dbtx.value),
+                fromDoubleUnit(
+                  dbtx.value.toString(),
                   decimals: _wallet.currency.decimals,
                 ),
                 id: dbtx.hash,
@@ -799,8 +799,8 @@ class WalletLogic extends WidgetsBindingObserver {
         limit: limit,
       ))
               .map((dbtx) => CWTransaction(
-                    fromUnit(
-                      BigInt.from(dbtx.value),
+                    fromDoubleUnit(
+                      dbtx.value.toString(),
                       decimals: _wallet.currency.decimals,
                     ),
                     id: dbtx.hash,
@@ -848,8 +848,8 @@ class WalletLogic extends WidgetsBindingObserver {
 
           txs.clear();
           txs.addAll(iterableRemoteTxs.map((dbtx) => CWTransaction(
-                fromUnit(
-                  BigInt.from(dbtx.value),
+                fromDoubleUnit(
+                  dbtx.value.toString(),
                   decimals: _wallet.currency.decimals,
                 ),
                 id: dbtx.hash,
@@ -920,10 +920,7 @@ class WalletLogic extends WidgetsBindingObserver {
     }
 
     return sendTransactionFromLocked(
-      '${toUnit(
-        tx.amount,
-        decimals: _wallet.currency.decimals,
-      )}',
+      tx.amount,
       tx.to,
       message: tx.title,
     );
@@ -968,8 +965,6 @@ class WalletLogic extends WidgetsBindingObserver {
       decimals: _wallet.currency.decimals,
     );
 
-    print(parsedAmount.toString());
-
     var tempId = id ?? '${pendingTransactionId}_${generateRandomId()}';
 
     try {
@@ -982,8 +977,8 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.preSendingTransaction(
         CWTransaction.sending(
-          fromUnit(
-            parsedAmount,
+          fromDoubleUnit(
+            parsedAmount.toString(),
             decimals: _wallet.currency.decimals,
           ),
           id: tempId,
@@ -1009,8 +1004,8 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.sendingTransaction(
         CWTransaction.sending(
-          fromUnit(
-            parsedAmount,
+          fromDoubleUnit(
+            parsedAmount.toString(),
             decimals: _wallet.currency.decimals,
           ),
           id: hash,
@@ -1046,8 +1041,8 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.pendingTransaction(
         CWTransaction.pending(
-          fromUnit(
-            parsedAmount,
+          fromDoubleUnit(
+            parsedAmount.toString(),
             decimals: _wallet.currency.decimals,
           ),
           id: hash,
@@ -1070,8 +1065,8 @@ class WalletLogic extends WidgetsBindingObserver {
     } on NetworkCongestedException {
       _state.sendQueueAddTransaction(
         CWTransaction.failed(
-            fromUnit(
-              parsedAmount,
+            fromDoubleUnit(
+              parsedAmount.toString(),
               decimals: _wallet.currency.decimals,
             ),
             id: tempId,
@@ -1084,8 +1079,8 @@ class WalletLogic extends WidgetsBindingObserver {
     } on NetworkInvalidBalanceException {
       _state.sendQueueAddTransaction(
         CWTransaction.failed(
-            fromUnit(
-              parsedAmount,
+            fromDoubleUnit(
+              parsedAmount.toString(),
               decimals: _wallet.currency.decimals,
             ),
             id: tempId,
@@ -1103,8 +1098,8 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.sendQueueAddTransaction(
         CWTransaction.failed(
-            fromUnit(
-              parsedAmount,
+            fromDoubleUnit(
+              parsedAmount.toString(),
               decimals: _wallet.currency.decimals,
             ),
             id: tempId,
@@ -1145,7 +1140,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.preSendingTransaction(
         CWTransaction.sending(
-          parsedAmount.toString(),
+          fromDoubleUnit(
+            parsedAmount.toString(),
+            decimals: _wallet.currency.decimals,
+          ),
           id: tempId,
           hash: '',
           chainId: _wallet.chainId,
@@ -1169,7 +1167,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.sendingTransaction(
         CWTransaction.sending(
-          parsedAmount.toString(),
+          fromDoubleUnit(
+            parsedAmount.toString(),
+            decimals: _wallet.currency.decimals,
+          ),
           id: hash,
           hash: '',
           chainId: _wallet.chainId,
@@ -1203,7 +1204,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.pendingTransaction(
         CWTransaction.pending(
-          parsedAmount.toString(),
+          fromDoubleUnit(
+            parsedAmount.toString(),
+            decimals: _wallet.currency.decimals,
+          ),
           id: hash,
           hash: '',
           chainId: _wallet.chainId,
@@ -1223,7 +1227,11 @@ class WalletLogic extends WidgetsBindingObserver {
       return true;
     } on NetworkCongestedException {
       _state.sendQueueAddTransaction(
-        CWTransaction.failed(parsedAmount.toString(),
+        CWTransaction.failed(
+            fromDoubleUnit(
+              parsedAmount.toString(),
+              decimals: _wallet.currency.decimals,
+            ),
             id: tempId,
             hash: '',
             to: to,
@@ -1233,7 +1241,11 @@ class WalletLogic extends WidgetsBindingObserver {
       );
     } on NetworkInvalidBalanceException {
       _state.sendQueueAddTransaction(
-        CWTransaction.failed(parsedAmount.toString(),
+        CWTransaction.failed(
+            fromDoubleUnit(
+              parsedAmount.toString(),
+              decimals: _wallet.currency.decimals,
+            ),
             id: tempId,
             hash: '',
             to: to,
@@ -1248,7 +1260,11 @@ class WalletLogic extends WidgetsBindingObserver {
       );
 
       _state.sendQueueAddTransaction(
-        CWTransaction.failed(parsedAmount.toString(),
+        CWTransaction.failed(
+            fromDoubleUnit(
+              parsedAmount.toString(),
+              decimals: _wallet.currency.decimals,
+            ),
             id: tempId,
             hash: '',
             to: to,

--- a/lib/state/wallet/logic.dart
+++ b/lib/state/wallet/logic.dart
@@ -571,7 +571,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
       final cwtransactions = txs.map(
         (tx) => CWTransaction(
-          fromUnit(tx.value),
+          fromUnit(
+            tx.value,
+            decimals: _wallet.currency.decimals,
+          ),
           id: tx.hash,
           hash: tx.txhash,
           chainId: _wallet.chainId,
@@ -688,7 +691,10 @@ class WalletLogic extends WidgetsBindingObserver {
         limit: limit,
       ))
               .map((dbtx) => CWTransaction(
-                    fromUnit(BigInt.from(dbtx.value)),
+                    fromUnit(
+                      BigInt.from(dbtx.value),
+                      decimals: _wallet.currency.decimals,
+                    ),
                     id: dbtx.hash,
                     hash: dbtx.txHash,
                     chainId: _wallet.chainId,
@@ -734,7 +740,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
           txs.clear();
           txs.addAll(iterableRemoteTxs.map((dbtx) => CWTransaction(
-                fromUnit(BigInt.from(dbtx.value)),
+                fromUnit(
+                  BigInt.from(dbtx.value),
+                  decimals: _wallet.currency.decimals,
+                ),
                 id: dbtx.hash,
                 hash: dbtx.txHash,
                 chainId: _wallet.chainId,
@@ -790,7 +799,10 @@ class WalletLogic extends WidgetsBindingObserver {
         limit: limit,
       ))
               .map((dbtx) => CWTransaction(
-                    fromUnit(BigInt.from(dbtx.value)),
+                    fromUnit(
+                      BigInt.from(dbtx.value),
+                      decimals: _wallet.currency.decimals,
+                    ),
                     id: dbtx.hash,
                     hash: dbtx.txHash,
                     chainId: _wallet.chainId,
@@ -836,7 +848,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
           txs.clear();
           txs.addAll(iterableRemoteTxs.map((dbtx) => CWTransaction(
-                fromUnit(BigInt.from(dbtx.value)),
+                fromUnit(
+                  BigInt.from(dbtx.value),
+                  decimals: _wallet.currency.decimals,
+                ),
                 id: dbtx.hash,
                 hash: dbtx.txHash,
                 chainId: _wallet.chainId,
@@ -904,8 +919,14 @@ class WalletLogic extends WidgetsBindingObserver {
       return false;
     }
 
-    return sendTransactionFromLocked('${double.parse(tx.amount) / 1000}', tx.to,
-        message: tx.title);
+    return sendTransactionFromLocked(
+      '${toUnit(
+        tx.amount,
+        decimals: _wallet.currency.decimals,
+      )}',
+      tx.to,
+      message: tx.title,
+    );
   }
 
   Future<bool> sendTransaction(String amount, String to,
@@ -917,8 +938,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
   bool isInvalidAmount(String amount) {
     final balance = double.tryParse(_state.wallet?.balance ?? '0.0') ?? 0.0;
-    final doubleAmount =
-        (double.tryParse(amount.replaceAll(',', '.')) ?? 0.0) * 1000;
+    final doubleAmount = double.parse(toUnit(
+      amount.replaceAll(',', '.'),
+      decimals: _wallet.currency.decimals,
+    ).toString());
 
     return doubleAmount == 0 || doubleAmount > balance;
   }
@@ -940,7 +963,12 @@ class WalletLogic extends WidgetsBindingObserver {
     String? id,
   }) async {
     final doubleAmount = amount.replaceAll(',', '.');
-    final parsedAmount = double.parse(doubleAmount) * 1000;
+    final parsedAmount = toUnit(
+      doubleAmount,
+      decimals: _wallet.currency.decimals,
+    );
+
+    print(parsedAmount.toString());
 
     var tempId = id ?? '${pendingTransactionId}_${generateRandomId()}';
 
@@ -954,7 +982,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.preSendingTransaction(
         CWTransaction.sending(
-          '$parsedAmount',
+          fromUnit(
+            parsedAmount,
+            decimals: _wallet.currency.decimals,
+          ),
           id: tempId,
           hash: '',
           chainId: _wallet.chainId,
@@ -966,7 +997,7 @@ class WalletLogic extends WidgetsBindingObserver {
 
       final calldata = _wallet.erc20TransferCallData(
         to,
-        BigInt.from(double.parse(doubleAmount) * 1000),
+        parsedAmount,
       );
 
       final (hash, userop) = await _wallet.prepareUserop(
@@ -978,7 +1009,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.sendingTransaction(
         CWTransaction.sending(
-          '$parsedAmount',
+          fromUnit(
+            parsedAmount,
+            decimals: _wallet.currency.decimals,
+          ),
           id: hash,
           hash: '',
           chainId: _wallet.chainId,
@@ -997,10 +1031,7 @@ class WalletLogic extends WidgetsBindingObserver {
           DateTime.now().toUtc(),
           _wallet.account,
           EthereumAddress.fromHex(to),
-          EtherAmount.fromBigInt(
-            EtherUnit.kwei,
-            BigInt.from(double.parse(doubleAmount) * 1000),
-          ).getInWei,
+          parsedAmount,
           Uint8List(0),
           TransactionState.sending.name,
         ),
@@ -1015,7 +1046,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.pendingTransaction(
         CWTransaction.pending(
-          '$parsedAmount',
+          fromUnit(
+            parsedAmount,
+            decimals: _wallet.currency.decimals,
+          ),
           id: hash,
           hash: '',
           chainId: _wallet.chainId,
@@ -1035,7 +1069,11 @@ class WalletLogic extends WidgetsBindingObserver {
       return true;
     } on NetworkCongestedException {
       _state.sendQueueAddTransaction(
-        CWTransaction.failed('$parsedAmount',
+        CWTransaction.failed(
+            fromUnit(
+              parsedAmount,
+              decimals: _wallet.currency.decimals,
+            ),
             id: tempId,
             hash: '',
             to: to,
@@ -1045,7 +1083,11 @@ class WalletLogic extends WidgetsBindingObserver {
       );
     } on NetworkInvalidBalanceException {
       _state.sendQueueAddTransaction(
-        CWTransaction.failed('$parsedAmount',
+        CWTransaction.failed(
+            fromUnit(
+              parsedAmount,
+              decimals: _wallet.currency.decimals,
+            ),
             id: tempId,
             hash: '',
             to: to,
@@ -1060,7 +1102,11 @@ class WalletLogic extends WidgetsBindingObserver {
       );
 
       _state.sendQueueAddTransaction(
-        CWTransaction.failed('$parsedAmount',
+        CWTransaction.failed(
+            fromUnit(
+              parsedAmount,
+              decimals: _wallet.currency.decimals,
+            ),
             id: tempId,
             hash: '',
             to: to,
@@ -1075,10 +1121,17 @@ class WalletLogic extends WidgetsBindingObserver {
     return false;
   }
 
-  Future<bool> sendTransactionFromUnlocked(String amount, String to,
-      {String message = '', String? id}) async {
+  Future<bool> sendTransactionFromUnlocked(
+    String amount,
+    String to, {
+    String message = '',
+    String? id,
+  }) async {
     final doubleAmount = amount.replaceAll(',', '.');
-    final parsedAmount = double.parse(doubleAmount) * 1000;
+    final parsedAmount = toUnit(
+      doubleAmount,
+      decimals: _wallet.currency.decimals,
+    );
 
     var tempId = id ?? '${pendingTransactionId}_${generateRandomId()}';
 
@@ -1092,7 +1145,7 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.preSendingTransaction(
         CWTransaction.sending(
-          '$parsedAmount',
+          parsedAmount.toString(),
           id: tempId,
           hash: '',
           chainId: _wallet.chainId,
@@ -1104,7 +1157,7 @@ class WalletLogic extends WidgetsBindingObserver {
 
       final calldata = _wallet.erc20TransferCallData(
         to,
-        BigInt.from(double.parse(doubleAmount) * 1000),
+        parsedAmount,
       );
 
       final (hash, userop) = await _wallet.prepareUserop(
@@ -1116,7 +1169,7 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.sendingTransaction(
         CWTransaction.sending(
-          '$parsedAmount',
+          parsedAmount.toString(),
           id: hash,
           hash: '',
           chainId: _wallet.chainId,
@@ -1135,16 +1188,12 @@ class WalletLogic extends WidgetsBindingObserver {
           DateTime.now().toUtc(),
           _wallet.account,
           EthereumAddress.fromHex(to),
-          EtherAmount.fromBigInt(
-            EtherUnit.kwei,
-            BigInt.from(double.parse(doubleAmount) * 1000),
-          ).getInWei,
+          parsedAmount,
           Uint8List(0),
           TransactionState.sending.name,
         ),
       );
 
-      // this needs to succeeds
       final success = await _wallet.submitUserop(userop);
       if (!success) {
         // this is an optional operation
@@ -1154,7 +1203,7 @@ class WalletLogic extends WidgetsBindingObserver {
 
       _state.pendingTransaction(
         CWTransaction.pending(
-          '$parsedAmount',
+          parsedAmount.toString(),
           id: hash,
           hash: '',
           chainId: _wallet.chainId,
@@ -1174,7 +1223,7 @@ class WalletLogic extends WidgetsBindingObserver {
       return true;
     } on NetworkCongestedException {
       _state.sendQueueAddTransaction(
-        CWTransaction.failed('$parsedAmount',
+        CWTransaction.failed(parsedAmount.toString(),
             id: tempId,
             hash: '',
             to: to,
@@ -1184,7 +1233,7 @@ class WalletLogic extends WidgetsBindingObserver {
       );
     } on NetworkInvalidBalanceException {
       _state.sendQueueAddTransaction(
-        CWTransaction.failed('$parsedAmount',
+        CWTransaction.failed(parsedAmount.toString(),
             id: tempId,
             hash: '',
             to: to,
@@ -1193,11 +1242,22 @@ class WalletLogic extends WidgetsBindingObserver {
             error: NetworkInvalidBalanceException().message),
       );
     } catch (exception, stackTrace) {
-      Sentry.captureException(
+      await Sentry.captureException(
         exception,
         stackTrace: stackTrace,
       );
+
+      _state.sendQueueAddTransaction(
+        CWTransaction.failed(parsedAmount.toString(),
+            id: tempId,
+            hash: '',
+            to: to,
+            title: message,
+            date: DateTime.now(),
+            error: NetworkUnknownException().message),
+      );
     }
+
     _state.sendTransactionError();
 
     return false;
@@ -1233,9 +1293,10 @@ class WalletLogic extends WidgetsBindingObserver {
   }
 
   void setMaxAmount() {
-    _amountController.text =
-        (double.parse(_state.wallet?.balance ?? '0.0') / 1000)
-            .toStringAsFixed(2);
+    _amountController.text = fromDoubleUnit(
+      _state.wallet?.balance ?? '0.0',
+      decimals: _wallet.currency.decimals,
+    );
     updateAmount();
   }
 
@@ -1525,7 +1586,11 @@ class WalletLogic extends WidgetsBindingObserver {
     try {
       _addressController.text = address;
 
-      _amountController.text = (double.parse(amount) / 1000).toStringAsFixed(2);
+      _amountController.text = double.parse('${toUnit(
+        amount,
+        decimals: _wallet.currency.decimals,
+      )}')
+          .toStringAsFixed(2);
 
       _messageController.text = message;
 

--- a/lib/utils/currency.dart
+++ b/lib/utils/currency.dart
@@ -13,8 +13,12 @@ String formatCurrency(double amount, String symbol,
               factor);
 }
 
-String formatAmount(double amount,
-    {int decimalDigits = 2, int factor = 1, bool? isIncoming}) {
+String formatAmount(
+  double amount, {
+  int decimalDigits = 2,
+  int factor = 1,
+  bool? isIncoming,
+}) {
   return NumberFormat.currency(
           symbol: isIncoming == null ? '' : (isIncoming ? '+ ' : '- '),
           decimalDigits: decimalDigits)

--- a/lib/utils/currency.dart
+++ b/lib/utils/currency.dart
@@ -1,7 +1,7 @@
 import 'package:intl/intl.dart';
 
 String formatCurrency(double amount, String symbol,
-    {int decimalDigits = 2, int factor = 1000, bool? isIncoming}) {
+    {int decimalDigits = 2, int factor = 1, bool? isIncoming}) {
   return NumberFormat.currency(
           locale: Intl.systemLocale,
           symbol: isIncoming == null
@@ -14,7 +14,7 @@ String formatCurrency(double amount, String symbol,
 }
 
 String formatAmount(double amount,
-    {int decimalDigits = 2, int factor = 1000, bool? isIncoming}) {
+    {int decimalDigits = 2, int factor = 1, bool? isIncoming}) {
   return NumberFormat.currency(
           symbol: isIncoming == null ? '' : (isIncoming ? '+ ' : '- '),
           decimalDigits: decimalDigits)

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -12,13 +12,13 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - Sentry/HybridSDK (8.9.1):
-    - SentryPrivate (= 8.9.1)
+  - Sentry/HybridSDK (8.11.0):
+    - SentryPrivate (= 8.11.0)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.9.1)
-  - SentryPrivate (8.9.1)
+    - Sentry/HybridSDK (= 8.11.0)
+  - SentryPrivate (8.11.0)
   - share_plus (0.0.1):
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
@@ -77,9 +77,9 @@ SPEC CHECKSUMS:
   mobile_scanner: ed7618fb749adc6574563e053f3b8e5002c13994
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
-  Sentry: e3203780941722a1fcfee99e351de14244c7f806
-  sentry_flutter: 8f0ffd53088e6a4d50c095852c5cad9e4405025c
-  SentryPrivate: 5e3683390f66611fc7c6215e27645873adb55d13
+  Sentry: 39d57e691e311bdb73bc1ab5bbebbd6bc890050d
+  sentry_flutter: b2feefdad5b0f06602347172bc7257e8e9da5562
+  SentryPrivate: 48712023cdfd523735c2edb6b06bedf26c4730a3
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   sqflite: a5789cceda41d54d23f31d6de539d65bb14100ea

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: archive
-      sha256: "49b1fad315e57ab0bbc15bcbb874e83116a1d78f77ebd500a4af6c9407d6b28e"
+      sha256: e0902a06f0e00414e4e3438a084580161279f137aeb862274710f29ec10cf01e
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.8"
+    version: "3.3.9"
   args:
     dependency: transitive
     description:
@@ -229,10 +229,10 @@ packages:
     dependency: "direct main"
     description:
       name: encrypt
-      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
+      sha256: c1f224c9a65df6f2cd111baaf31edd2f31d3f094abdb22a3b0bbcc64698ef80d
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.2"
   fake_async:
     dependency: transitive
     description:
@@ -314,10 +314,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: d4a1cb250c4e059586af0235f32e02882860a508e189b61f2b31b8810c1e1330
+      sha256: a10979814c5f4ddbe2b6143fba25d927599e21e3ba65b3862995960606fae78f
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17+2"
+    version: "0.6.17+3"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -924,10 +924,10 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "39c23342fc96105da449914f7774139a17a0ca8a4e70d9ad5200171f7e47d6ba"
+      sha256: "830667eadc0398fea3a3424ed1b74568e2db603a42758d0922e2f2974ce55a60"
       url: "https://pub.dev"
     source: hosted
-    version: "7.9.0"
+    version: "7.10.1"
   sentry_dart_plugin:
     dependency: "direct dev"
     description:
@@ -940,10 +940,10 @@ packages:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: ff68ab31918690da004a42e20204242a3ad9ad57da7e2712da8487060ac9767f
+      sha256: "6730f41b304c6fb0fa590dacccaf73ba11082fc64b274cfe8a79776f2b95309c"
       url: "https://pub.dev"
     source: hosted
-    version: "7.9.0"
+    version: "7.10.1"
   share_plus:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Tokens now support a dynamic amount of decimals. It used to be hardcoded to 6, a common standard. Tested and working for 18 decimals.

Voucher links did not explicitly include an alias, this could cause deep linking issues. 