### PR TITLE
Account renaming fix + account switching improvements

### DIFF
--- a/lib/modals/account/switch_account.dart
+++ b/lib/modals/account/switch_account.dart
@@ -3,7 +3,6 @@ import 'package:citizenwallet/modals/wallet/community_picker.dart';
 import 'package:citizenwallet/screens/wallet/wallet_row.dart';
 import 'package:citizenwallet/state/communities/logic.dart';
 import 'package:citizenwallet/state/communities/selectors.dart';
-import 'package:citizenwallet/state/profile/logic.dart';
 import 'package:citizenwallet/state/profiles/logic.dart';
 import 'package:citizenwallet/state/profiles/state.dart';
 import 'package:citizenwallet/state/wallet/logic.dart';
@@ -183,7 +182,7 @@ class SwitchAccountModalState extends State<SwitchAccountModal> {
         return;
       }
 
-      await widget.logic.editWallet(address, newName);
+      await widget.logic.editWallet(address, alias, newName);
 
       HapticFeedback.heavyImpact();
       return;

--- a/lib/modals/account/switch_account.dart
+++ b/lib/modals/account/switch_account.dart
@@ -119,6 +119,7 @@ class SwitchAccountModalState extends State<SwitchAccountModal> {
     String alias,
     String name,
     bool locked,
+    bool hasProfile,
   ) async {
     final wallet = context.read<WalletState>().wallet;
 
@@ -129,13 +130,14 @@ class SwitchAccountModalState extends State<SwitchAccountModal> {
         builder: (BuildContext dialogContext) {
           return CupertinoActionSheet(
             actions: [
-              CupertinoActionSheetAction(
-                isDefaultAction: true,
-                onPressed: () {
-                  Navigator.of(dialogContext).pop('edit');
-                },
-                child: const Text('Edit name'),
-              ),
+              if (!hasProfile)
+                CupertinoActionSheetAction(
+                  isDefaultAction: true,
+                  onPressed: () {
+                    Navigator.of(dialogContext).pop('edit');
+                  },
+                  child: const Text('Edit name'),
+                ),
               if (!locked)
                 CupertinoActionSheetAction(
                   onPressed: () {
@@ -361,6 +363,7 @@ class SwitchAccountModalState extends State<SwitchAccountModal> {
                                   wallet.alias,
                                   wallet.name,
                                   wallet.locked,
+                                  profiles.containsKey(wallet.account),
                                 ),
                                 onLoadProfile: handleLoadProfile,
                               );

--- a/lib/modals/profile/edit.dart
+++ b/lib/modals/profile/edit.dart
@@ -1,6 +1,7 @@
 import 'package:citizenwallet/services/wallet/contracts/profile.dart';
 import 'package:citizenwallet/state/profile/logic.dart';
 import 'package:citizenwallet/state/profile/state.dart';
+import 'package:citizenwallet/state/wallet/logic.dart';
 import 'package:citizenwallet/state/wallet/state.dart';
 import 'package:citizenwallet/theme/colors.dart';
 import 'package:citizenwallet/utils/delay.dart';
@@ -34,6 +35,7 @@ class EditProfileModalState extends State<EditProfileModal> {
   final FocusNode descriptionFocusNode = FocusNode();
 
   late ProfileLogic _logic;
+  late WalletLogic _walletLogic;
 
   late Debounce debouncedHandleUsernameUpdate;
   late Debounce debouncedHandleNameUpdate;
@@ -44,6 +46,7 @@ class EditProfileModalState extends State<EditProfileModal> {
     super.initState();
 
     _logic = ProfileLogic(context);
+    _walletLogic = WalletLogic(context);
 
     debouncedHandleUsernameUpdate = debounce(
       (String username) {
@@ -115,16 +118,25 @@ class EditProfileModalState extends State<EditProfileModal> {
     HapticFeedback.lightImpact();
 
     final wallet = context.read<WalletState>().wallet;
+    final newName = context.read<ProfileState>().nameController.value.text;
+
+    if (wallet == null) {
+      return;
+    }
 
     final success = await _logic.save(
       ProfileV1(
-        account: wallet?.account ?? '',
+        account: wallet.account,
       ),
       image,
     );
 
     if (!success) {
       return;
+    }
+
+    if (newName.isNotEmpty) {
+      await _walletLogic.editWallet(wallet.address, wallet.alias, newName);
     }
 
     HapticFeedback.heavyImpact();
@@ -137,15 +149,24 @@ class EditProfileModalState extends State<EditProfileModal> {
     HapticFeedback.lightImpact();
 
     final wallet = context.read<WalletState>().wallet;
+    final newName = context.read<ProfileState>().nameController.value.text;
+
+    if (wallet == null) {
+      return;
+    }
 
     final success = await _logic.update(
       ProfileV1(
-        account: wallet?.account ?? '',
+        account: wallet.account,
       ),
     );
 
     if (!success) {
       return;
+    }
+
+    if (newName.isNotEmpty) {
+      await _walletLogic.editWallet(wallet.address, wallet.alias, newName);
     }
 
     HapticFeedback.heavyImpact();

--- a/lib/modals/profile/edit.dart
+++ b/lib/modals/profile/edit.dart
@@ -81,6 +81,8 @@ class EditProfileModalState extends State<EditProfileModal> {
   @override
   void dispose() {
     debouncedHandleUsernameUpdate.cancel();
+    debouncedHandleNameUpdate.cancel();
+    debouncedHandleDescriptionUpdate.cancel();
     _logic.resetEdit();
     super.dispose();
   }

--- a/lib/modals/wallet/receive.dart
+++ b/lib/modals/wallet/receive.dart
@@ -159,9 +159,7 @@ class ReceiveModalState extends State<ReceiveModal> {
                               data: qrData,
                               size: qrSize - 20,
                               padding: const EdgeInsets.all(20),
-                              logo: isExternalWallet
-                                  ? 'assets/icons/wallet.png'
-                                  : null,
+                              logo: isExternalWallet ? null : 'assets/logo.png',
                             ),
                           ),
                         ],

--- a/lib/screens/account/screen.dart
+++ b/lib/screens/account/screen.dart
@@ -174,8 +174,9 @@ class AccountScreenState extends State<AccountScreen> {
 
     final profileLoading = loading || profile.loading;
 
-    final hasNoProfile =
-        profile.username == '' && profile.name == '' && profile.image == '';
+    final hasNoProfile = profile.username.isEmpty &&
+        profile.name.isEmpty &&
+        profile.image.isEmpty;
 
     final profileLink =
         context.select((ProfileState state) => state.profileLink);
@@ -327,7 +328,9 @@ class AccountScreenState extends State<AccountScreen> {
                                       children: [
                                         Expanded(
                                           child: Text(
-                                            wallet.name,
+                                            hasNoProfile
+                                                ? wallet.name
+                                                : '@${profile.username}',
                                             maxLines: 1,
                                             overflow: TextOverflow.ellipsis,
                                             style: TextStyle(

--- a/lib/screens/wallet/wallet_scroll_view.dart
+++ b/lib/screens/wallet/wallet_scroll_view.dart
@@ -197,7 +197,7 @@ class WalletScrollViewState extends State<WalletScrollView> {
                     data: qrData,
                     size: qrSize,
                     padding: const EdgeInsets.all(20),
-                    logo: isExternalWallet ? 'assets/icons/wallet.png' : null,
+                    logo: isExternalWallet ? null : 'assets/logo.png',
                   ),
                 ),
                 const SizedBox(

--- a/lib/services/encrypted_preferences/encrypted_preferences.dart
+++ b/lib/services/encrypted_preferences/encrypted_preferences.dart
@@ -55,7 +55,8 @@ class BackupWallet {
   }
 
   String get legacyKey => '$backupPrefix${address.toLowerCase()}';
-  String get legacyKey2 => '$backupPrefix$legacyHash}';
+  String get legacyKey2 =>
+      '$backupPrefix$legacyHash}'; // the typo '}' is intentional, a typo was released to production
   String get key => '$backupPrefix$hashed';
   String get value => '$name|$address|$privateKey|$alias';
 }

--- a/lib/services/encrypted_preferences/encrypted_preferences.dart
+++ b/lib/services/encrypted_preferences/encrypted_preferences.dart
@@ -23,7 +23,7 @@ class BackupWallet {
   final String alias;
 
   BackupWallet({
-    address,
+    required String address,
     required this.privateKey,
     required this.name,
     required this.alias,
@@ -42,14 +42,21 @@ class BackupWallet {
         'alias': alias,
       };
 
-  String get hashed {
+  String get legacyHash {
     final bytes = keccak256(convertStringToUint8List(value));
 
     return bytesToHex(bytes);
   }
 
+  String get hashed {
+    final bytes = keccak256(convertStringToUint8List('$address|$alias'));
+
+    return bytesToHex(bytes);
+  }
+
   String get legacyKey => '$backupPrefix${address.toLowerCase()}';
-  String get key => '$backupPrefix$hashed}';
+  String get legacyKey2 => '$backupPrefix$legacyHash}';
+  String get key => '$backupPrefix$hashed';
   String get value => '$name|$address|$privateKey|$alias';
 }
 
@@ -59,7 +66,7 @@ abstract class EncryptedPreferencesOptions {}
 ///
 /// This is used to store wallet backups and the implementation is platform specific.
 abstract class EncryptedPreferencesService {
-  final int _version = 1;
+  final int _version = 2;
 
   int get version => _version;
 

--- a/lib/state/profile/logic.dart
+++ b/lib/state/profile/logic.dart
@@ -134,8 +134,25 @@ class ProfileLogic {
     try {
       _state.setProfileRequest();
 
-      final profile =
-          await _wallet.getProfile(account ?? _wallet.account.hexEip55);
+      final acc = account ?? _wallet.account.hexEip55;
+
+      final cachedProfile =
+          _profiles.profiles.containsKey(acc) ? _profiles.profiles[acc] : null;
+
+      if (cachedProfile?.profile != null) {
+        final profile = cachedProfile!.profile;
+        _state.setProfileSuccess(
+          account: profile.account,
+          username: profile.username,
+          name: profile.name,
+          description: profile.description,
+          image: profile.image,
+          imageMedium: profile.imageMedium,
+          imageSmall: profile.imageSmall,
+        );
+      }
+
+      final profile = await _wallet.getProfile(acc);
       if (profile == null) {
         await delay(const Duration(milliseconds: 500));
         _state.setProfileNoChangeSuccess();
@@ -170,6 +187,14 @@ class ProfileLogic {
   Future<void> loadViewProfile(String account) async {
     try {
       _state.viewProfileRequest();
+
+      final cachedProfile = _profiles.profiles.containsKey(account)
+          ? _profiles.profiles[account]
+          : null;
+
+      if (cachedProfile?.profile != null) {
+        _state.viewProfileSuccess(cachedProfile!.profile);
+      }
 
       final profile = await _wallet.getProfile(account);
       if (profile == null) {

--- a/lib/state/profile/logic.dart
+++ b/lib/state/profile/logic.dart
@@ -239,14 +239,17 @@ class ProfileLogic {
         imageSmall: newProfile.imageSmall,
       );
 
-      _db.contacts.insert(DBContact(
+      _db.contacts.insert(
+        DBContact(
           account: newProfile.account,
           username: newProfile.username,
           name: newProfile.name,
           description: newProfile.description,
           image: newProfile.image,
           imageMedium: newProfile.imageMedium,
-          imageSmall: newProfile.imageSmall));
+          imageSmall: newProfile.imageSmall,
+        ),
+      );
 
       _profiles.isLoaded(
         newProfile.account,

--- a/lib/state/vouchers/logic.dart
+++ b/lib/state/vouchers/logic.dart
@@ -183,8 +183,6 @@ class VoucherLogic extends WidgetsBindingObserver {
 
       final balance = await _wallet.getBalance(address);
 
-      print('balance: $balance');
-
       await _db.vouchers.updateBalance(address, balance);
 
       final voucher = Voucher(

--- a/lib/state/wallet/logic.dart
+++ b/lib/state/wallet/logic.dart
@@ -319,8 +319,6 @@ class WalletLogic extends WidgetsBindingObserver {
 
       return null;
     } catch (exception, stackTrace) {
-      print(exception);
-      print(stackTrace);
       Sentry.captureException(
         exception,
         stackTrace: stackTrace,

--- a/lib/state/wallet/logic.dart
+++ b/lib/state/wallet/logic.dart
@@ -494,18 +494,15 @@ class WalletLogic extends WidgetsBindingObserver {
     return null;
   }
 
-  Future<void> editWallet(String address, String name) async {
+  Future<void> editWallet(String address, String alias, String name) async {
     try {
-      final config = await _config.config;
-
-      final dbWallet =
-          await _encPrefs.getWalletBackup(address, config.community.alias);
+      final dbWallet = await _encPrefs.getWalletBackup(address, alias);
       if (dbWallet == null) {
         throw NotFoundException();
       }
 
       await _encPrefs.setWalletBackup(BackupWallet(
-        address: address,
+        address: EthereumAddress.fromHex(address).hexEip55,
         privateKey: dbWallet.privateKey,
         name: name,
         alias: dbWallet.alias,
@@ -513,7 +510,10 @@ class WalletLogic extends WidgetsBindingObserver {
 
       loadDBWallets();
 
-      _state.updateCurrentWalletName(name);
+      if (_state.wallet?.address == address) {
+        // only update current name if it's the same wallet
+        _state.updateCurrentWalletName(name);
+      }
 
       return;
     } on NotFoundException {

--- a/lib/state/wallet/state.dart
+++ b/lib/state/wallet/state.dart
@@ -485,7 +485,7 @@ class WalletState with ChangeNotifier {
   }
 
   void loadWalletsSuccess(List<CWWallet> wallets) {
-    this.wallets = wallets;
+    this.wallets = [...wallets];
 
     cwWalletsLoading = false;
     cwWalletsError = false;

--- a/lib/widgets/profile/profile_qr_badge.dart
+++ b/lib/widgets/profile/profile_qr_badge.dart
@@ -54,6 +54,7 @@ class ProfileQRBadge extends StatelessWidget {
               child: QR(
                 data: profileLink,
                 size: width - 140,
+                logo: 'assets/logo.png',
               ),
             ),
           ),

--- a/lib/widgets/profile/profile_qr_badge.dart
+++ b/lib/widgets/profile/profile_qr_badge.dart
@@ -84,7 +84,11 @@ class ProfileQRBadge extends StatelessWidget {
                       maxWidth: 200,
                     ),
                     child: Text(
-                      hasNoProfile ? '' : '@${profile?.username ?? ''}',
+                      !hasNoProfile &&
+                              profile != null &&
+                              profile!.username.isNotEmpty
+                          ? '@${profile?.username ?? ''}'
+                          : '',
                       style: TextStyle(
                         color: ThemeColors.black.resolveFrom(context),
                         fontSize: 16,

--- a/lib/widgets/profile/profile_qr_badge.dart
+++ b/lib/widgets/profile/profile_qr_badge.dart
@@ -84,7 +84,7 @@ class ProfileQRBadge extends StatelessWidget {
                       maxWidth: 200,
                     ),
                     child: Text(
-                      '@${profile?.username ?? ''}',
+                      hasNoProfile ? '' : '@${profile?.username ?? ''}',
                       style: TextStyle(
                         color: ThemeColors.black.resolveFrom(context),
                         fontSize: 16,

--- a/lib/widgets/qr/qr.dart
+++ b/lib/widgets/qr/qr.dart
@@ -40,7 +40,7 @@ class QR extends StatelessWidget {
             dataModuleShape: QrDataModuleShape.circle,
             color: ThemeColors.black,
           ),
-          embeddedImage: AssetImage(logo ?? 'assets/logo.png'),
+          embeddedImage: logo != null ? AssetImage(logo!) : null,
           embeddedImageStyle: QrEmbeddedImageStyle(
             size: Size(imageSize, imageSize),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: citizenwallet
-version: 1.0.33+80
+version: 1.0.34+80
 publish_to: none
 description: A mobile wallet for your community.
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: citizenwallet
-version: 1.0.34+80
+version: 1.0.34+81
 publish_to: none
 description: A mobile wallet for your community.
 environment:


### PR DESCRIPTION
- renaming an account from a different community than the one currently selected, creates a duplicate wallet
- display the profile name and user name in favor of the wallet name
- edit the wallet name when editing the profile name
- don't allow editing the wallet name when a username is set