### PR TITLE
refactor(accounts): update getAllAccounts to return DBAccountV4

### DIFF
--- a/lib/services/accounts/accounts.dart
+++ b/lib/services/accounts/accounts.dart
@@ -31,7 +31,7 @@ abstract class AccountsServiceInterface {
   // key = wb_$wallet_address, value = $name|$privateKey
 
   // get all accounts
-  Future<List<DBAccount>> getAllAccounts();
+  Future<List<DBAccountV4>> getAllAccounts();
 
   // set account
   Future<void> setAccount(DBAccount account);

--- a/lib/services/accounts/native/android.dart
+++ b/lib/services/accounts/native/android.dart
@@ -189,8 +189,8 @@ class AndroidAccountsService extends AccountsServiceInterface {
 
   // get all wallet backups
   @override
-  Future<List<DBAccount>> getAllAccounts() async {
-    final List<DBAccount> accounts = await _accountsDB.accounts.all();
+  Future<List<DBAccountV4>> getAllAccounts() async {
+    final List<DBAccountV4> accounts = await _accountsDB.accounts.all();
 
     for (final account in accounts) {
       final privateKey = await _credentials.read(account.id);

--- a/lib/services/accounts/native/apple.dart
+++ b/lib/services/accounts/native/apple.dart
@@ -302,8 +302,8 @@ class AppleAccountsService extends AccountsServiceInterface {
 
   // get all wallet backups
   @override
-  Future<List<DBAccount>> getAllAccounts() async {
-    final List<DBAccount> accounts = await _accountsDB.accounts.all();
+  Future<List<DBAccountV4>> getAllAccounts() async {
+    final List<DBAccountV4> accounts = await _accountsDB.accounts.all();
 
     for (final account in accounts) {
       final privateKey = await _credentials.read(account.id);

--- a/lib/services/accounts/web.dart
+++ b/lib/services/accounts/web.dart
@@ -32,7 +32,7 @@ class WebAccountsService extends AccountsServiceInterface {
 
   // get all wallet backups
   @override
-  Future<List<DBAccount>> getAllAccounts() async {
+  Future<List<DBAccountV4>> getAllAccounts() async {
     return [];
   }
 

--- a/lib/services/db/backup/accounts.dart
+++ b/lib/services/db/backup/accounts.dart
@@ -317,11 +317,11 @@ class AccountsTable extends DBTable {
     await db.delete(name);
   }
 
-  Future<List<DBAccount>> all() async {
+  Future<List<DBAccountV4>> all() async {
     final List<Map<String, dynamic>> maps = await db.query(name);
 
     return List.generate(maps.length, (i) {
-      return DBAccount.fromMap(maps[i]);
+      return DBAccountV4.fromMap(maps[i]);
     });
   }
 


### PR DESCRIPTION
- Update AccountsServiceInterface to use DBAccountV4 for account retrieval.
- Migrate Android, Apple, and Web account service implementations to DBAccountV4.
- Update AccountsTable.all() to fetch and map records using DBAccountV4.fromMap.
- Ensure type consistency across account backup services following the v4 database migration.